### PR TITLE
Fix manageMembership userId SQL error

### DIFF
--- a/src/main/java/my/nexgenesports/dao/memberships/UserClubMembershipDaoImpl.java
+++ b/src/main/java/my/nexgenesports/dao/memberships/UserClubMembershipDaoImpl.java
@@ -37,7 +37,7 @@ public class UserClubMembershipDaoImpl implements UserClubMembershipDao {
     @Override
     public UserClubMembership findLatestByUser(String userId) throws SQLException {
         String sql = """
-            SELECT id, sessionId, purchaseDate, expiryDate, status, payment_reference
+            SELECT id, userId, sessionId, purchaseDate, expiryDate, status, payment_reference
               FROM userclubmemberships
              WHERE userId = ?
                AND status = 'ACTIVE'

--- a/src/main/java/my/nexgenesports/dao/memberships/UserGamingPassDaoImpl.java
+++ b/src/main/java/my/nexgenesports/dao/memberships/UserGamingPassDaoImpl.java
@@ -36,7 +36,7 @@ public class UserGamingPassDaoImpl implements UserGamingPassDao {
     @Override
     public UserGamingPass findLatestByUser(String userId) throws SQLException {
         String sql = """
-            SELECT id, tierId, purchaseDate, expiryDate, paymentReference
+            SELECT id, userId, tierId, purchaseDate, expiryDate, paymentReference
               FROM usergamingpasses
              WHERE userId = ?
              ORDER BY expiryDate DESC


### PR DESCRIPTION
## Summary
- fix SQL queries for retrieving latest pass & membership

## Testing
- `mvn -q -DskipTests compile` *(fails: `mvn` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68552fe291b8833387ba06e34e77ab4e