### PR TITLE
Fix merit level lookup and handle nullable fields

### DIFF
--- a/src/main/java/my/nexgenesports/controller/programTournament/ProgramTournamentCreateServlet.java
+++ b/src/main/java/my/nexgenesports/controller/programTournament/ProgramTournamentCreateServlet.java
@@ -51,20 +51,47 @@ public class ProgramTournamentCreateServlet extends HttpServlet {
                     ? (String) session.getAttribute("username")
                     : null;
             pt.setCreatorId(creator);
-            pt.setGameId(Integer.valueOf(req.getParameter("gameId")));
+
+            String gameId = req.getParameter("gameId");
+            pt.setGameId(gameId != null && !gameId.isBlank()
+                    ? Integer.valueOf(gameId) : null);
+
             pt.setProgramName(req.getParameter("programName"));
-            pt.setProgramType(req.getParameter("programType"));
-            pt.setMeritId(Integer.valueOf(req.getParameter("meritId")));
+
+            String programType = req.getParameter("programType");
+            pt.setProgramType(programType);
+
+            String scope = req.getParameter("meritScope");
+            pt.setMeritId(svc.resolveMeritId(programType, scope));
+
             pt.setPlace(req.getParameter("place"));
             pt.setDescription(req.getParameter("description"));
-            pt.setProgFee(new BigDecimal(req.getParameter("progFee")));
+
+            String fee = req.getParameter("progFee");
+            pt.setProgFee(fee != null && !fee.isBlank()
+                    ? new BigDecimal(fee) : null);
+
             pt.setStartDate(LocalDate.parse(req.getParameter("startDate")));
             pt.setEndDate(LocalDate.parse(req.getParameter("endDate")));
-            pt.setStartTime(LocalTime.parse(req.getParameter("startTime")));
-            pt.setEndTime(LocalTime.parse(req.getParameter("endTime")));
-            pt.setPrizePool(new BigDecimal(req.getParameter("prizePool")));
+
+            String st = req.getParameter("startTime");
+            pt.setStartTime(st != null && !st.isBlank()
+                    ? LocalTime.parse(st) : null);
+
+            String et = req.getParameter("endTime");
+            pt.setEndTime(et != null && !et.isBlank()
+                    ? LocalTime.parse(et) : null);
+
+            String pool = req.getParameter("prizePool");
+            pt.setPrizePool(pool != null && !pool.isBlank()
+                    ? new BigDecimal(pool) : null);
+
             pt.setMaxCapacity(Integer.parseInt(req.getParameter("maxCapacity")));
-            pt.setMaxTeamMember(Integer.valueOf(req.getParameter("maxTeamMember")));
+
+            String mtm = req.getParameter("maxTeamMember");
+            pt.setMaxTeamMember(mtm != null && !mtm.isBlank()
+                    ? Integer.valueOf(mtm) : null);
+
             pt.setStatus("PENDING");  // default status
 
             svc.createProgramTournament(pt);

--- a/src/main/java/my/nexgenesports/dao/programTournament/MeritLevelDao.java
+++ b/src/main/java/my/nexgenesports/dao/programTournament/MeritLevelDao.java
@@ -9,6 +9,7 @@ public interface MeritLevelDao {
     MeritLevel insert(MeritLevel ml) throws SQLException;
     MeritLevel findById(int meritId) throws SQLException;
     List<MeritLevel> findAll() throws SQLException;
+    MeritLevel findByCategoryAndScope(String category, String scope) throws SQLException;
     void update(MeritLevel ml) throws SQLException;
     void delete(int meritId) throws SQLException;
 }

--- a/src/main/java/my/nexgenesports/dao/programTournament/MeritLevelDaoImpl.java
+++ b/src/main/java/my/nexgenesports/dao/programTournament/MeritLevelDaoImpl.java
@@ -60,6 +60,20 @@ public class MeritLevelDaoImpl implements MeritLevelDao {
     }
 
     @Override
+    public MeritLevel findByCategoryAndScope(String category, String scope) throws SQLException {
+        String sql = "SELECT * FROM merit_level WHERE category = ? AND scope = ?";
+        try (Connection c = DBConnection.getConnection();
+             PreparedStatement ps = c.prepareStatement(sql)) {
+
+            ps.setString(1, category);
+            ps.setString(2, scope);
+            try (ResultSet rs = ps.executeQuery()) {
+                return rs.next() ? mapRow(rs) : null;
+            }
+        }
+    }
+
+    @Override
     public void update(MeritLevel ml) throws SQLException {
         String sql = """
             UPDATE merit_level

--- a/src/main/java/my/nexgenesports/dao/programTournament/ProgramTournamentDaoImpl.java
+++ b/src/main/java/my/nexgenesports/dao/programTournament/ProgramTournamentDaoImpl.java
@@ -38,7 +38,8 @@ public class ProgramTournamentDaoImpl implements ProgramTournamentDao {
             VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, 0)
             """;
 
-        try (Connection c = DBConnection.getConnection(); PreparedStatement ps = c.prepareStatement(sql)) {
+        try (Connection c = DBConnection.getConnection();
+             PreparedStatement ps = c.prepareStatement(sql, Statement.RETURN_GENERATED_KEYS)) {
 
             ps.setString(1, pt.getCreatorId());
 

--- a/src/main/java/my/nexgenesports/service/programTournament/ProgramTournamentService.java
+++ b/src/main/java/my/nexgenesports/service/programTournament/ProgramTournamentService.java
@@ -208,6 +208,17 @@ public class ProgramTournamentService {
         }
     }
 
+    public Integer resolveMeritId(String programType, String scope) {
+        String category = "PROGRAM".equalsIgnoreCase(programType)
+                ? "Program" : "Tournament";
+        try {
+            MeritLevel ml = meritDao.findByCategoryAndScope(category, scope);
+            return ml != null ? ml.getMeritId() : null;
+        } catch (SQLException e) {
+            throw new ServiceException("Failed merits", e);
+        }
+    }
+
     /**
      * LIST ALL (any status)
      *


### PR DESCRIPTION
## Summary
- map merit level by category and scope so `meritScope` + `programType` can resolve a merit id
- avoid parsing blank form fields in `ProgramTournamentCreateServlet`
- return generated keys when inserting a program or tournament

## Testing
- `mvn -q -DskipTests=false test` *(fails: `mvn` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6860dbbdb3d08333930171349f75d634