### PR TITLE
Fix merit scope dropdown

### DIFF
--- a/src/main/java/my/nexgenesports/controller/programTournament/ProgramTournamentCreateServlet.java
+++ b/src/main/java/my/nexgenesports/controller/programTournament/ProgramTournamentCreateServlet.java
@@ -29,13 +29,18 @@ public class ProgramTournamentCreateServlet extends HttpServlet {
         var games = new GameService().listGames();
         req.setAttribute("games", games);
 
-        List<String> scopes = null;
+        List<String> scopes;
         try {
             scopes = new ProgramTournamentDaoImpl().findAllScopes();
+            if (scopes == null || scopes.isEmpty()) {
+                scopes = List.of("Club", "University", "State", "National", "International");
+            }
         } catch (SQLException ex) {
             Logger.getLogger(ProgramTournamentCreateServlet.class.getName()).log(Level.SEVERE, null, ex);
+            scopes = List.of("Club", "University", "State", "National", "International");
         }
         req.setAttribute("scopes", scopes);
+        req.setAttribute("scopesJson", new com.fasterxml.jackson.databind.ObjectMapper().writeValueAsString(scopes));
 
         req.getRequestDispatcher("/programCreate.jsp")
                 .forward(req, resp);
@@ -51,20 +56,47 @@ public class ProgramTournamentCreateServlet extends HttpServlet {
                     ? (String) session.getAttribute("username")
                     : null;
             pt.setCreatorId(creator);
-            pt.setGameId(Integer.valueOf(req.getParameter("gameId")));
+
+            String gameId = req.getParameter("gameId");
+            pt.setGameId(gameId != null && !gameId.isBlank()
+                    ? Integer.valueOf(gameId) : null);
+
             pt.setProgramName(req.getParameter("programName"));
-            pt.setProgramType(req.getParameter("programType"));
-            pt.setMeritId(Integer.valueOf(req.getParameter("meritId")));
+
+            String programType = req.getParameter("programType");
+            pt.setProgramType(programType);
+
+            String scope = req.getParameter("meritScope");
+            pt.setMeritId(svc.resolveMeritId(programType, scope));
+
             pt.setPlace(req.getParameter("place"));
             pt.setDescription(req.getParameter("description"));
-            pt.setProgFee(new BigDecimal(req.getParameter("progFee")));
+
+            String fee = req.getParameter("progFee");
+            pt.setProgFee(fee != null && !fee.isBlank()
+                    ? new BigDecimal(fee) : null);
+
             pt.setStartDate(LocalDate.parse(req.getParameter("startDate")));
             pt.setEndDate(LocalDate.parse(req.getParameter("endDate")));
-            pt.setStartTime(LocalTime.parse(req.getParameter("startTime")));
-            pt.setEndTime(LocalTime.parse(req.getParameter("endTime")));
-            pt.setPrizePool(new BigDecimal(req.getParameter("prizePool")));
+
+            String st = req.getParameter("startTime");
+            pt.setStartTime(st != null && !st.isBlank()
+                    ? LocalTime.parse(st) : null);
+
+            String et = req.getParameter("endTime");
+            pt.setEndTime(et != null && !et.isBlank()
+                    ? LocalTime.parse(et) : null);
+
+            String pool = req.getParameter("prizePool");
+            pt.setPrizePool(pool != null && !pool.isBlank()
+                    ? new BigDecimal(pool) : null);
+
             pt.setMaxCapacity(Integer.parseInt(req.getParameter("maxCapacity")));
-            pt.setMaxTeamMember(Integer.valueOf(req.getParameter("maxTeamMember")));
+
+            String mtm = req.getParameter("maxTeamMember");
+            pt.setMaxTeamMember(mtm != null && !mtm.isBlank()
+                    ? Integer.valueOf(mtm) : null);
+
             pt.setStatus("PENDING");  // default status
 
             svc.createProgramTournament(pt);

--- a/src/main/java/my/nexgenesports/dao/programTournament/MeritLevelDao.java
+++ b/src/main/java/my/nexgenesports/dao/programTournament/MeritLevelDao.java
@@ -9,6 +9,7 @@ public interface MeritLevelDao {
     MeritLevel insert(MeritLevel ml) throws SQLException;
     MeritLevel findById(int meritId) throws SQLException;
     List<MeritLevel> findAll() throws SQLException;
+    MeritLevel findByCategoryAndScope(String category, String scope) throws SQLException;
     void update(MeritLevel ml) throws SQLException;
     void delete(int meritId) throws SQLException;
 }

--- a/src/main/java/my/nexgenesports/dao/programTournament/MeritLevelDaoImpl.java
+++ b/src/main/java/my/nexgenesports/dao/programTournament/MeritLevelDaoImpl.java
@@ -60,6 +60,20 @@ public class MeritLevelDaoImpl implements MeritLevelDao {
     }
 
     @Override
+    public MeritLevel findByCategoryAndScope(String category, String scope) throws SQLException {
+        String sql = "SELECT * FROM merit_level WHERE category = ? AND scope = ?";
+        try (Connection c = DBConnection.getConnection();
+             PreparedStatement ps = c.prepareStatement(sql)) {
+
+            ps.setString(1, category);
+            ps.setString(2, scope);
+            try (ResultSet rs = ps.executeQuery()) {
+                return rs.next() ? mapRow(rs) : null;
+            }
+        }
+    }
+
+    @Override
     public void update(MeritLevel ml) throws SQLException {
         String sql = """
             UPDATE merit_level

--- a/src/main/java/my/nexgenesports/dao/programTournament/ProgramTournamentDaoImpl.java
+++ b/src/main/java/my/nexgenesports/dao/programTournament/ProgramTournamentDaoImpl.java
@@ -38,7 +38,8 @@ public class ProgramTournamentDaoImpl implements ProgramTournamentDao {
             VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, 0)
             """;
 
-        try (Connection c = DBConnection.getConnection(); PreparedStatement ps = c.prepareStatement(sql)) {
+        try (Connection c = DBConnection.getConnection();
+             PreparedStatement ps = c.prepareStatement(sql, Statement.RETURN_GENERATED_KEYS)) {
 
             ps.setString(1, pt.getCreatorId());
 

--- a/src/main/java/my/nexgenesports/service/programTournament/ProgramTournamentService.java
+++ b/src/main/java/my/nexgenesports/service/programTournament/ProgramTournamentService.java
@@ -208,6 +208,17 @@ public class ProgramTournamentService {
         }
     }
 
+    public Integer resolveMeritId(String programType, String scope) {
+        String category = "PROGRAM".equalsIgnoreCase(programType)
+                ? "Program" : "Tournament";
+        try {
+            MeritLevel ml = meritDao.findByCategoryAndScope(category, scope);
+            return ml != null ? ml.getMeritId() : null;
+        } catch (SQLException e) {
+            throw new ServiceException("Failed merits", e);
+        }
+    }
+
     /**
      * LIST ALL (any status)
      *

--- a/src/main/webapp/programCreate.jsp
+++ b/src/main/webapp/programCreate.jsp
@@ -52,9 +52,6 @@
                     <label for="meritScope">Level</label>
                     <select id="meritScope" name="meritScope" required>
                         <option value="">-- select level --</option>
-                        <c:forEach var="scope" items="${scopes}">
-                            <option value="${scope}">${scope}</option>
-                        </c:forEach>
                     </select>
                 </div>
 
@@ -126,17 +123,40 @@
             </form>
         </main>
 
+        <script id="scopesData" type="application/json">
+            ${scopesJson}
+        </script>
         <script>
             document.addEventListener('DOMContentLoaded', () => {
                 const typeSel = document.getElementById('programType');
                 const gameGrp = document.getElementById('gameGroup');
                 const teamGrp = document.getElementById('teamMemberGroup');
+                const scopeSel = document.getElementById('meritScope');
+                const scopes = JSON.parse(document.getElementById('scopesData').textContent || '[]');
+
+                function populateScopes() {
+                    scopeSel.innerHTML = '<option value="">-- select level --</option>';
+                    scopes.forEach(sc => {
+                        const opt = document.createElement('option');
+                        opt.value = sc;
+                        opt.textContent = sc;
+                        scopeSel.appendChild(opt);
+                    });
+                }
 
                 typeSel.addEventListener('change', () => {
                     const isTour = typeSel.value === 'TOURNAMENT';
                     gameGrp.style.display = isTour ? 'block' : 'none';
                     teamGrp.style.display = isTour ? 'block' : 'none';
+                    populateScopes();
+                    scopeSel.disabled = !typeSel.value;
                 });
+
+                // initial population
+                scopeSel.disabled = !typeSel.value;
+                if (typeSel.value) {
+                    populateScopes();
+                }
             });
         </script>
     </body>


### PR DESCRIPTION
## Summary
- fall back to constant merit scopes if DB lookup fails
- embed scope list as JSON so the create form script can populate options
- populate level dropdown dynamically when program type is selected

## Testing
- `mvn -q -DskipTests=false test` *(fails: `mvn` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6860dbbdb3d08333930171349f75d634